### PR TITLE
Add folder compilation cli tests

### DIFF
--- a/.changeset/mighty-ants-tie.md
+++ b/.changeset/mighty-ants-tie.md
@@ -1,0 +1,5 @@
+---
+"@ts-r/cli": patch
+---
+
+added folder compilation tests for cli

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,5 +1,18 @@
-import { Failable, FileOutput, Id } from "@ts-r/core";
-import { setupTestDir } from "@ts-r/core/__tests__/helpers/testFileIO";
+import {
+  Failable,
+  FileOutput,
+  fileOutput,
+  getFullFilePath,
+  Id,
+} from "@ts-r/core";
+import {
+  createTestDir,
+  readTest,
+  setupTestDir,
+  wrapInTestDir,
+  writeTest,
+} from "@ts-r/core/__tests__/helpers/testFileIO";
+import path = require("path");
 
 import { cli } from "../src/cli";
 
@@ -56,6 +69,208 @@ describe(cli, () => {
     expect(logs.includes("Usage: ")).toBeTruthy();
     expect(logs.includes(""));
     expect(exited).toBe(true);
+  });
+
+  it("Should handle folder compilation", () => {
+    type file = {
+      readonly name: string;
+      readonly content: string | readonly file[];
+    };
+    const writeTestDir = (testFile: file, dir?: string) => {
+      if (typeof testFile.content === "string") {
+        // file is not a directory, so write it at the current directory
+        writeTest(
+          wrapInTestDir(`${dir}${path.sep}${testFile.name}`),
+          testFile.content
+        );
+      } else {
+        // file is a directory - so create it, walk the kids and append this directory
+        createTestDir(
+          dir === undefined
+            ? testFile.name
+            : `${dir}${path.sep}${testFile.name}`
+        );
+        testFile.content.forEach((subFile) =>
+          writeTestDir(
+            subFile,
+            dir === undefined
+              ? testFile.name
+              : `${dir}${path.sep}${testFile.name}`
+          )
+        );
+      }
+    };
+    const compareTestDir = (expectedFile: file, dir?: string) => {
+      if (typeof expectedFile.content === "string") {
+        // file is not a directory, so compare the actual file's contents
+        // against the expected file's contents
+        expect(
+          readTest(wrapInTestDir(`${dir}${path.sep}${expectedFile.name}`))
+        ).toBe(expectedFile.content);
+      } else {
+        // file is a directory - so walk the kids, append this directory
+        // and validate each child
+        expectedFile.content.forEach((subFile) =>
+          compareTestDir(
+            subFile,
+            dir === undefined
+              ? expectedFile.name
+              : `${dir}${path.sep}${expectedFile.name}`
+          )
+        );
+      }
+    };
+
+    const testDirName = "in_dir";
+
+    const inDir: file = {
+      name: testDirName,
+      content: [
+        {
+          name: "file1.tsr.ts",
+          content: "export type T = {a: string;};",
+        },
+        {
+          name: "file2.tsr.ts",
+          content: "export type U = {c: boolean;};",
+        },
+        {
+          name: "dir1",
+          content: [
+            {
+              name: "dir1file1.tsr.ts",
+              content: "export type S = {b: number;};",
+            },
+            {
+              name: "dir2",
+              content: [
+                {
+                  name: "dir1dir2file1.tsr.ts",
+                  content: "export type K = {l: string;};",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const outDir: file = {
+      name: testDirName,
+      content: [
+        {
+          name: "file1.tsr.o.ts",
+          content:
+            "export const T_$TSR = {\n" +
+            `    id: "${cliTestID}",\n` +
+            '    type: "object",\n' +
+            "    properties: {\n" +
+            "        a: {\n" +
+            '            type: "propertySignature",\n' +
+            "            optional: false,\n" +
+            `            tsRuntimeObject: { id: "${cliTestID}", type: "string" }\n` +
+            "        }\n" +
+            "    }\n" +
+            "} as const;\n",
+        },
+        {
+          name: "file2.tsr.o.ts",
+          content:
+            "export const U_$TSR = {\n" +
+            `    id: "${cliTestID}",\n` +
+            '    type: "object",\n' +
+            "    properties: {\n" +
+            "        c: {\n" +
+            '            type: "propertySignature",\n' +
+            "            optional: false,\n" +
+            `            tsRuntimeObject: { id: "${cliTestID}", type: "boolean" }\n` +
+            "        }\n" +
+            "    }\n" +
+            "} as const;\n",
+        },
+        {
+          name: "dir1",
+          content: [
+            {
+              name: "dir1file1.tsr.o.ts",
+              content:
+                "export const S_$TSR = {\n" +
+                `    id: "${cliTestID}",\n` +
+                '    type: "object",\n' +
+                "    properties: {\n" +
+                "        b: {\n" +
+                '            type: "propertySignature",\n' +
+                "            optional: false,\n" +
+                `            tsRuntimeObject: { id: "${cliTestID}", type: "number" }\n` +
+                "        }\n" +
+                "    }\n" +
+                "} as const;\n",
+            },
+            {
+              name: "dir2",
+              content: [
+                {
+                  name: "dir1dir2file1.tsr.o.ts",
+                  content:
+                    "export const K_$TSR = {\n" +
+                    `    id: "${cliTestID}",\n` +
+                    '    type: "object",\n' +
+                    "    properties: {\n" +
+                    "        l: {\n" +
+                    '            type: "propertySignature",\n' +
+                    "            optional: false,\n" +
+                    `            tsRuntimeObject: { id: "${cliTestID}", type: "string" }\n` +
+                    "        }\n" +
+                    "    }\n" +
+                    "} as const;\n",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Write inDir test files
+    writeTestDir(inDir);
+
+    // Run CLI on inDir
+    let logs = "";
+    let errors = "";
+    let exited = false;
+
+    cli({
+      deps: {
+        commanderProgram: {
+          exitOverride() {
+            exited = true;
+          },
+        },
+        fileOutput: fileOutput,
+        args: {
+          getArgs() {
+            return [getFullFilePath(wrapInTestDir(testDirName))];
+          },
+          startsOnActualArguments: true,
+        },
+        logger: {
+          log(text) {
+            logs += `${text}\n`;
+          },
+          error(text) {
+            errors += `${text}\n`;
+          },
+        },
+        id: testIdGenerator,
+      },
+    });
+
+    // Ensure that the cli ran without error and didn't exit prematurely
+    expect(errors).toBe("");
+    expect(logs).toBe("");
+    expect(exited).toBe(false);
+
+    // Compare outDir with
+    compareTestDir(outDir);
   });
 
   test.todo("ADD MANY MORE TESTS");

--- a/packages/core/__tests__/helpers/testFileIO.ts
+++ b/packages/core/__tests__/helpers/testFileIO.ts
@@ -1,17 +1,25 @@
 import fs from "fs";
+import * as path from "path";
 
-import { getFullFilePath, Path, wrap } from "../../src/Path";
+import { getFullFilePath, Path, wrap } from "../../src";
 
 export const TEST_DIR = "TEMP_TEST_DIR";
 
 export const setupTestDir = () => {
   // Create an empty temporary test directory
-  if (fs.existsSync(TEST_DIR)) fs.rmdirSync(TEST_DIR, { recursive: true });
-  fs.mkdirSync(TEST_DIR);
+  if (!fs.existsSync(TEST_DIR)) fs.mkdirSync(TEST_DIR);
+};
+
+export const createTestDir = (subDir: string) => {
+  subDir = `${TEST_DIR}${path.sep}${subDir}`;
+  if (!fs.existsSync(subDir)) fs.mkdirSync(subDir);
 };
 
 export const writeTest = (filePath: Path, input: string) =>
   fs.writeFileSync(getFullFilePath(filePath), input);
+
+export const readTest = (filePath: Path) =>
+  fs.readFileSync(getFullFilePath(filePath)).toString();
 
 export const wrapInTestDir = (filename: string) => wrap(filename, TEST_DIR);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,12 +74,12 @@ importers:
       typescript: ^4.6.3
     dependencies:
       chokidar: 3.5.3
-      commander: 9.3.0
-      typescript: 4.7.4
+      commander: 9.4.0
+      typescript: 4.6.4
     devDependencies:
       '@ts-r/core': link:../core
       '@types/node': 17.0.45
-      ts-node: 10.8.1_x2utdhayajzrh747hktprshhby
+      ts-node: 10.8.1_laqv367ntbladgchwutjrnj4ky
 
   packages/core:
     specifiers: {}
@@ -650,15 +650,6 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /@commitlint/config-validator/17.0.0:
-    resolution: {integrity: sha512-78IQjoZWR4kDHp/U5y17euEWzswJpPkA9TDL5F6oZZZaLIEreWzrDZD5PWtM8MsSRl/K2LDU/UrzYju2bKLMpA==}
-    engines: {node: '>=v14'}
-    dependencies:
-      '@commitlint/types': 17.0.0
-      ajv: 6.12.6
-    dev: true
-    optional: true
-
   /@commitlint/cz-commitlint/16.2.3_frbpfwmum4k22jlgfu5ls6ndgu:
     resolution: {integrity: sha512-G9rRnBJ/5te7RiOzp7EdqII9rQYvtsfsqwMxcoK4B7l0Rc57nFCOlf0e4Bn70E4aOsLeMzNe+PvVVrEsPStEHg==}
     engines: {node: '>=v12'}
@@ -691,12 +682,6 @@ packages:
     resolution: {integrity: sha512-oSls82fmUTLM6cl5V3epdVo4gHhbmBFvCvQGHBRdQ50H/690Uq1Dyd7hXMuKITCIdcnr9umyDkr8r5C6HZDF3g==}
     engines: {node: '>=v12'}
     dev: true
-
-  /@commitlint/execute-rule/17.0.0:
-    resolution: {integrity: sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==}
-    engines: {node: '>=v14'}
-    dev: true
-    optional: true
 
   /@commitlint/format/16.2.1:
     resolution: {integrity: sha512-Yyio9bdHWmNDRlEJrxHKglamIk3d6hC0NkEUW6Ti6ipEh2g0BAhy8Od6t4vLhdZRa1I2n+gY13foy+tUgk0i1Q==}
@@ -744,28 +729,6 @@ packages:
       - '@swc/wasm'
     dev: true
 
-  /@commitlint/load/17.0.0:
-    resolution: {integrity: sha512-XaiHF4yWQOPAI0O6wXvk+NYLtJn/Xb7jgZEeKd4C1ZWd7vR7u8z5h0PkWxSr0uLZGQsElGxv3fiZ32C5+q6M8w==}
-    engines: {node: '>=v14'}
-    requiresBuild: true
-    dependencies:
-      '@commitlint/config-validator': 17.0.0
-      '@commitlint/execute-rule': 17.0.0
-      '@commitlint/resolve-extends': 17.0.0
-      '@commitlint/types': 17.0.0
-      '@types/node': 17.0.23
-      chalk: 4.1.2
-      cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 2.0.2_3xkz3jgsc4ddk27kgxyjwdfefm
-      lodash: 4.17.21
-      resolve-from: 5.0.0
-      typescript: 4.6.4
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-    dev: true
-    optional: true
-
   /@commitlint/message/16.2.1:
     resolution: {integrity: sha512-2eWX/47rftViYg7a3axYDdrgwKv32mxbycBJT6OQY/MJM7SUfYNYYvbMFOQFaA4xIVZt7t2Alyqslbl6blVwWw==}
     engines: {node: '>=v12'}
@@ -802,19 +765,6 @@ packages:
       resolve-global: 1.0.0
     dev: true
 
-  /@commitlint/resolve-extends/17.0.0:
-    resolution: {integrity: sha512-wi60WiJmwaQ7lzMXK8Vbc18Hq9tE2j/6iv2AFfPUGV7fvfY6Sf1iNKuUHirSqR0fquUyufIXe4y/K9A6LVIIvw==}
-    engines: {node: '>=v14'}
-    dependencies:
-      '@commitlint/config-validator': 17.0.0
-      '@commitlint/types': 17.0.0
-      import-fresh: 3.3.0
-      lodash: 4.17.21
-      resolve-from: 5.0.0
-      resolve-global: 1.0.0
-    dev: true
-    optional: true
-
   /@commitlint/rules/16.2.4:
     resolution: {integrity: sha512-rK5rNBIN2ZQNQK+I6trRPK3dWa0MtaTN4xnwOma1qxa4d5wQMQJtScwTZjTJeallFxhOgbNOgr48AMHkdounVg==}
     engines: {node: '>=v12'}
@@ -844,14 +794,6 @@ packages:
     dependencies:
       chalk: 4.1.2
     dev: true
-
-  /@commitlint/types/17.0.0:
-    resolution: {integrity: sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==}
-    engines: {node: '>=v14'}
-    dependencies:
-      chalk: 4.1.2
-    dev: true
-    optional: true
 
   /@cspotcode/source-map-support/0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2207,8 +2149,8 @@ packages:
     engines: {node: '>= 12'}
     dev: true
 
-  /commander/9.3.0:
-    resolution: {integrity: sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==}
+  /commander/9.4.0:
+    resolution: {integrity: sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==}
     engines: {node: ^12.20.0 || >=14}
     dev: false
 
@@ -2388,7 +2330,7 @@ packages:
       longest: 2.0.1
       word-wrap: 1.2.3
     optionalDependencies:
-      '@commitlint/load': 17.0.0
+      '@commitlint/load': 16.3.0
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -6132,7 +6074,7 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-node/10.8.1_x2utdhayajzrh747hktprshhby:
+  /ts-node/10.8.1_laqv367ntbladgchwutjrnj4ky:
     resolution: {integrity: sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==}
     hasBin: true
     peerDependencies:
@@ -6158,7 +6100,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.7.4
+      typescript: 4.6.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -6379,12 +6321,6 @@ packages:
 
   /typescript/4.6.4:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 


### PR DESCRIPTION
This PR contains:
- tests for cli folder compilation
- these tests ensure that the cli can be passed a directory and will walk the directory, correctly compiling any .tsr.ts files in those directories

fixes: #131 