### PR TITLE
Test cli watch mode

### DIFF
--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,11 +1,13 @@
 import { Failable, FileOutput, fileOutput, Id } from "@ts-r/core";
 import {
   appendToTest,
+  createTestDir,
   readTest,
   setupTestDir,
   wrapInTestDir,
   writeTest,
 } from "@ts-r/core/__tests__/helpers/testFileIO";
+import path = require("path");
 
 import { cli } from "../src/cli";
 
@@ -138,6 +140,276 @@ describe(cli, () => {
         "    value: 2\n" +
         "} as const;\n"
     );
+  });
+
+  it("Should auto-compile when a watched directory has changes", async () => {
+    type file = {
+      readonly name: string;
+      readonly content: string | readonly file[];
+    };
+    const writeTestDir = (testFile: file, dir?: string) => {
+      if (typeof testFile.content === "string") {
+        // file is not a directory, so write it at the current directory
+        writeTest(
+          wrapInTestDir(`${dir}${path.sep}${testFile.name}`),
+          testFile.content
+        );
+      } else {
+        // file is a directory - so create it, walk the kids and append this directory
+        createTestDir(
+          dir === undefined
+            ? testFile.name
+            : `${dir}${path.sep}${testFile.name}`
+        );
+        testFile.content.forEach((subFile) =>
+          writeTestDir(
+            subFile,
+            dir === undefined
+              ? testFile.name
+              : `${dir}${path.sep}${testFile.name}`
+          )
+        );
+      }
+    };
+    const compareTestDir = (expectedFile: file, dir?: string) => {
+      if (typeof expectedFile.content === "string") {
+        // file is not a directory, so compare the actual file's contents
+        // against the expected file's contents
+        expect(
+          readTest(wrapInTestDir(`${dir}${path.sep}${expectedFile.name}`))
+        ).toBe(expectedFile.content);
+      } else {
+        // file is a directory - so walk the kids, append this directory
+        // and validate each child
+        expectedFile.content.forEach((subFile) =>
+          compareTestDir(
+            subFile,
+            dir === undefined
+              ? expectedFile.name
+              : `${dir}${path.sep}${expectedFile.name}`
+          )
+        );
+      }
+    };
+
+    const testDirName = "watch_dir";
+
+    const watchDir: file = {
+      name: testDirName,
+      content: [
+        {
+          name: "file1.tsr.ts",
+          content: "export type T = {a: string;};",
+        },
+        {
+          name: "file2.tsr.ts",
+          content: "export type U = {c: boolean;};",
+        },
+        {
+          name: "dir1",
+          content: [
+            {
+              name: "dir1file1.tsr.ts",
+              content: "export type S = {b: number;};",
+            },
+          ],
+        },
+      ],
+    };
+    const additionalDir: file = {
+      name: `${testDirName}${path.sep}dir1${path.sep}dir2`,
+      content: [
+        {
+          name: "dir1dir2file1.tsr.ts",
+          content: "export type K = {l: string;};",
+        },
+      ],
+    };
+
+    const outDirPre: file = {
+      name: testDirName,
+      content: [
+        {
+          name: "file1.tsr.o.ts",
+          content:
+            "export const T_$TSR = {\n" +
+            `    id: "${cliTestID}",\n` +
+            '    type: "object",\n' +
+            "    properties: {\n" +
+            "        a: {\n" +
+            '            type: "propertySignature",\n' +
+            "            optional: false,\n" +
+            `            tsRuntimeObject: { id: "${cliTestID}", type: "string" }\n` +
+            "        }\n" +
+            "    }\n" +
+            "} as const;\n",
+        },
+        {
+          name: "file2.tsr.o.ts",
+          content:
+            "export const U_$TSR = {\n" +
+            `    id: "${cliTestID}",\n` +
+            '    type: "object",\n' +
+            "    properties: {\n" +
+            "        c: {\n" +
+            '            type: "propertySignature",\n' +
+            "            optional: false,\n" +
+            `            tsRuntimeObject: { id: "${cliTestID}", type: "boolean" }\n` +
+            "        }\n" +
+            "    }\n" +
+            "} as const;\n",
+        },
+        {
+          name: "dir1",
+          content: [
+            {
+              name: "dir1file1.tsr.o.ts",
+              content:
+                "export const S_$TSR = {\n" +
+                `    id: "${cliTestID}",\n` +
+                '    type: "object",\n' +
+                "    properties: {\n" +
+                "        b: {\n" +
+                '            type: "propertySignature",\n' +
+                "            optional: false,\n" +
+                `            tsRuntimeObject: { id: "${cliTestID}", type: "number" }\n` +
+                "        }\n" +
+                "    }\n" +
+                "} as const;\n",
+            },
+          ],
+        },
+      ],
+    };
+    const outDirPost: file = {
+      name: testDirName,
+      content: [
+        {
+          name: "file1.tsr.o.ts",
+          content:
+            "export const T_$TSR = {\n" +
+            `    id: "${cliTestID}",\n` +
+            '    type: "object",\n' +
+            "    properties: {\n" +
+            "        a: {\n" +
+            '            type: "propertySignature",\n' +
+            "            optional: false,\n" +
+            `            tsRuntimeObject: { id: "${cliTestID}", type: "string" }\n` +
+            "        }\n" +
+            "    }\n" +
+            "} as const;\n",
+        },
+        {
+          name: "file2.tsr.o.ts",
+          content:
+            "export const U_$TSR = {\n" +
+            `    id: "${cliTestID}",\n` +
+            '    type: "object",\n' +
+            "    properties: {\n" +
+            "        c: {\n" +
+            '            type: "propertySignature",\n' +
+            "            optional: false,\n" +
+            `            tsRuntimeObject: { id: "${cliTestID}", type: "boolean" }\n` +
+            "        }\n" +
+            "    }\n" +
+            "} as const;\n",
+        },
+        {
+          name: "dir1",
+          content: [
+            {
+              name: "dir1file1.tsr.o.ts",
+              content:
+                "export const S_$TSR = {\n" +
+                `    id: "${cliTestID}",\n` +
+                '    type: "object",\n' +
+                "    properties: {\n" +
+                "        b: {\n" +
+                '            type: "propertySignature",\n' +
+                "            optional: false,\n" +
+                `            tsRuntimeObject: { id: "${cliTestID}", type: "number" }\n` +
+                "        }\n" +
+                "    }\n" +
+                "} as const;\n",
+            },
+            {
+              name: "dir2",
+              content: [
+                {
+                  name: "dir1dir2file1.tsr.o.ts",
+                  content:
+                    "export const K_$TSR = {\n" +
+                    `    id: "${cliTestID}",\n` +
+                    '    type: "object",\n' +
+                    "    properties: {\n" +
+                    "        l: {\n" +
+                    '            type: "propertySignature",\n' +
+                    "            optional: false,\n" +
+                    `            tsRuntimeObject: { id: "${cliTestID}", type: "string" }\n` +
+                    "        }\n" +
+                    "    }\n" +
+                    "} as const;\n",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    // Write watchDir test files
+    writeTestDir(watchDir);
+
+    // Run CLI on watchDir
+    let logs = "";
+    let errors = "";
+    let exited = false;
+
+    cli({
+      deps: {
+        commanderProgram: {
+          exitOverride() {
+            exited = true;
+          },
+        },
+        fileOutput: fileOutput,
+        args: {
+          getArgs() {
+            return ["-w", wrapInTestDir(testDirName).getFullFilePath()];
+          },
+          startsOnActualArguments: true,
+        },
+        logger: {
+          log(text) {
+            logs += `${text}\n`;
+          },
+          error(text) {
+            errors += `${text}\n`;
+          },
+        },
+        id: testIdGenerator,
+      },
+    });
+
+    // Wait for the file to be written
+    await new Promise((f) => setTimeout(f, 3000));
+
+    // Ensure that the cli ran without error and didn't exit prematurely
+    expect(errors).toBe("");
+    expect(logs).toBe("");
+    expect(exited).toBe(false);
+
+    // Ensure that the watcher generated all the files currently in the directory
+    compareTestDir(outDirPre);
+
+    // Write the additional directory
+    writeTestDir(additionalDir);
+
+    // Wait for the watcher to compile the new directory
+    await new Promise((f) => setTimeout(f, 10000));
+
+    // Ensure that the watcher noticed and generated the new directory
+    compareTestDir(outDirPost);
   });
 
   test.todo("ADD MANY MORE TESTS");

--- a/packages/cli/__tests__/cli.test.ts
+++ b/packages/cli/__tests__/cli.test.ts
@@ -1,5 +1,11 @@
-import { Failable, FileOutput, Id } from "@ts-r/core";
-import { setupTestDir } from "@ts-r/core/__tests__/helpers/testFileIO";
+import { Failable, FileOutput, fileOutput, Id } from "@ts-r/core";
+import {
+  appendToTest,
+  readTest,
+  setupTestDir,
+  wrapInTestDir,
+  writeTest,
+} from "@ts-r/core/__tests__/helpers/testFileIO";
 
 import { cli } from "../src/cli";
 
@@ -23,7 +29,6 @@ describe(cli, () => {
     let errors = "";
     let exited = false;
 
-    console.log("Running CLI");
     expect(
       cli({
         deps: {
@@ -56,6 +61,83 @@ describe(cli, () => {
     expect(logs.includes("Usage: ")).toBeTruthy();
     expect(logs.includes(""));
     expect(exited).toBe(true);
+  });
+
+  it("Should auto-compile when a watch file changes", async () => {
+    // Create the file to be watched
+    const watchFile = wrapInTestDir("watch.tsr.ts");
+    const watchFileOutput = wrapInTestDir("watch.tsr.o.ts");
+    writeTest(watchFile, "export type T = 1;");
+
+    // Watch the file
+    let logs = "";
+    let errors = "";
+    let exited = false;
+    cli({
+      deps: {
+        commanderProgram: {
+          exitOverride() {
+            exited = true;
+          },
+        },
+        fileOutput: fileOutput,
+        args: {
+          getArgs() {
+            return ["-w", watchFile.getFullFilePath()];
+          },
+          startsOnActualArguments: true,
+        },
+        logger: {
+          log(text) {
+            logs += `${text}\n`;
+          },
+          error(text) {
+            errors += `${text}\n`;
+          },
+        },
+        id: testIdGenerator,
+      },
+    });
+
+    // Ensure there aren't any errors while watching the file
+    expect(errors).toBe("");
+    expect(logs.includes(""));
+    expect(exited).toBe(false);
+
+    // Wait for the file to be written
+    await new Promise((f) => setTimeout(f, 3000));
+
+    // Validate the file that the cli compiled
+    expect(readTest(watchFileOutput)).toBe(
+      "export const T_$TSR = {\n" +
+        `    id: "${cliTestID}",\n` +
+        '    type: "literal",\n' +
+        '    typeLiteral: "number",\n' +
+        "    value: 1\n" +
+        "} as const;\n"
+    );
+
+    // Make a change to the watched file
+    appendToTest(watchFile, "\nexport type U = 2;");
+
+    // Wait for the changes made to the file to propagate
+    await new Promise((f) => setTimeout(f, 3000));
+
+    // Ensure those changes were picked up by the file watcher
+    expect(readTest(watchFileOutput)).toBe(
+      "export const T_$TSR = {\n" +
+        `    id: "${cliTestID}",\n` +
+        '    type: "literal",\n' +
+        '    typeLiteral: "number",\n' +
+        "    value: 1\n" +
+        "} as const;\n" +
+        "export const U_$TSR = {\n" +
+        `    id: "${cliTestID}",\n` +
+        '    type: "literal",\n' +
+        '    typeLiteral: "number",\n' +
+        "    value: 2\n" +
+        "} as const;\n"
+    );
   });
 
   test.todo("ADD MANY MORE TESTS");

--- a/packages/core/__tests__/helpers/testFileIO.ts
+++ b/packages/core/__tests__/helpers/testFileIO.ts
@@ -1,19 +1,24 @@
 import fs from "fs";
 
-import { getFullFilePath, Path, wrap } from "../../src/Path";
+import Path from "../../src/Path";
 
 export const TEST_DIR = "TEMP_TEST_DIR";
 
 export const setupTestDir = () => {
   // Create an empty temporary test directory
-  if (fs.existsSync(TEST_DIR)) fs.rmdirSync(TEST_DIR, { recursive: true });
-  fs.mkdirSync(TEST_DIR);
+  if (!fs.existsSync(TEST_DIR)) fs.mkdirSync(TEST_DIR);
 };
 
 export const writeTest = (filePath: Path, input: string) =>
-  fs.writeFileSync(getFullFilePath(filePath), input);
+  fs.writeFileSync(filePath.getFullFilePath(), input);
 
-export const wrapInTestDir = (filename: string) => wrap(filename, TEST_DIR);
+export const appendToTest = (filePath: Path, data: string) =>
+  fs.appendFileSync(filePath.getFullFilePath(), data);
+
+export const readTest = (filePath: Path) =>
+  fs.readFileSync(filePath.getFullFilePath()).toString();
+
+export const wrapInTestDir = (filename: string) => new Path(filename, TEST_DIR);
 
 export const teardownTestDir = () => {
   fs.rmdirSync(TEST_DIR, { recursive: true });

--- a/packages/core/__tests__/helpers/testFileIO.ts
+++ b/packages/core/__tests__/helpers/testFileIO.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path = require("path");
 
 import Path from "../../src/Path";
 
@@ -7,6 +8,11 @@ export const TEST_DIR = "TEMP_TEST_DIR";
 export const setupTestDir = () => {
   // Create an empty temporary test directory
   if (!fs.existsSync(TEST_DIR)) fs.mkdirSync(TEST_DIR);
+};
+
+export const createTestDir = (subDir: string) => {
+  subDir = `${TEST_DIR}${path.sep}${subDir}`;
+  if (!fs.existsSync(subDir)) fs.mkdirSync(subDir);
 };
 
 export const writeTest = (filePath: Path, input: string) =>

--- a/packages/core/__tests__/transform.test.ts
+++ b/packages/core/__tests__/transform.test.ts
@@ -1,6 +1,6 @@
 import prettier from "prettier";
 
-import { getFullFilePath, transform } from "../src";
+import { transform } from "../src";
 import { Id } from "../src/deps/Id";
 import { Failable } from "../src/Failable";
 import { setupTestDir, wrapInTestDir, writeTest } from "./helpers/testFileIO";
@@ -42,7 +42,7 @@ const genericTypeChecker = ({
 
     const transformResult = transform(
       {
-        filename: getFullFilePath(filename),
+        filename: filename.getFullFilePath(),
         outputFilename: `${filename}.output.ts`,
         prependTsCode,
       },

--- a/packages/core/src/Path.ts
+++ b/packages/core/src/Path.ts
@@ -1,10 +1,17 @@
 import path from "path";
 
-export type Path = { path: string; filename: string };
+class Path {
+  path: string;
+  filename: string;
 
-export const wrap = (filename: string, path: string) => {
-  return { path, filename } as Path;
-};
+  constructor(filename: string, path: string) {
+    this.filename = filename;
+    this.path = path;
+  }
 
-export const getFullFilePath = (wrappedPath: Path) =>
-  `${wrappedPath.path}${path.sep}${wrappedPath.filename}`;
+  getFullFilePath() {
+    return `${this.path}${path.sep}${this.filename}`;
+  }
+}
+
+export default Path;


### PR DESCRIPTION
This PR contains the following tests which ensure that the watcher can detect changes made to:
-  individual files
-  files within directories and new directories added within a directory
fixes: #130
