### PR TITLE
Add support bigint and never

### DIFF
--- a/.changeset/many-berries-refuse.md
+++ b/.changeset/many-berries-refuse.md
@@ -1,0 +1,6 @@
+---
+"@ts-r/core": patch
+"@ts-r/utils": patch
+---
+
+visitor can now handle the never keyword and bigint literals and NeverTSRObj was added to utils

--- a/packages/core/src/lib/visit/visit.ts
+++ b/packages/core/src/lib/visit/visit.ts
@@ -4,6 +4,7 @@ import { getSourceFile } from "../helpers/getSourceFile";
 import { Visiter } from "../helpers/types";
 import { visitAnyKeyword } from "./visitAnyKeyword";
 import { visitArrayType } from "./visitArrayType";
+import { visitBigInt } from "./visitBigInt";
 import { visitBooleanKeyword } from "./visitBooleanKeyword";
 import { visitBooleanLiteral } from "./visitBooleanLiteral";
 import { visitClassDeclaration } from "./visitClassDeclaration";
@@ -14,6 +15,7 @@ import { visitImportDeclaration } from "./visitImportDeclaration";
 import { visitInterfaceDeclaration } from "./visitInterfaceDeclaration";
 import { visitIntersectionType } from "./visitIntersectionType";
 import { visitLiteralType } from "./visitLiteralType";
+import { visitNever } from "./visitNever";
 import { visitNullKeyword } from "./visitNullKeyword";
 import { visitNumberKeyword } from "./visitNumberKeyword";
 import { visitNumericLiteral } from "./visitNumericLiteral";
@@ -69,6 +71,8 @@ export const visitMap: Partial<Record<ts.SyntaxKind, Visiter<any>>> = {
   [ts.SyntaxKind.TypeOperator]: visitTypeOperator,
   [ts.SyntaxKind.ClassDeclaration]: visitClassDeclaration,
   [ts.SyntaxKind.LiteralType]: visitLiteralType,
+  [ts.SyntaxKind.NeverKeyword]: visitNever,
+  [ts.SyntaxKind.BigIntLiteral]: visitBigInt,
 };
 
 export const visit: Visiter = ({ deps, node, metadata }): ts.Node => {

--- a/packages/core/src/lib/visit/visitBigInt.ts
+++ b/packages/core/src/lib/visit/visitBigInt.ts
@@ -1,0 +1,7 @@
+import ts from "typescript";
+
+import { Visiter } from "../helpers/types";
+
+export const visitBigInt: Visiter<ts.BigIntLiteral> = ({ node }) => {
+  return ts.factory.createBigIntLiteral(node.text);
+};

--- a/packages/core/src/lib/visit/visitBigInt.ts
+++ b/packages/core/src/lib/visit/visitBigInt.ts
@@ -2,6 +2,22 @@ import ts from "typescript";
 
 import { Visiter } from "../helpers/types";
 
-export const visitBigInt: Visiter<ts.BigIntLiteral> = ({ node }) => {
-  return ts.factory.createBigIntLiteral(node.text);
-};
+export const visitBigInt: Visiter<ts.BigIntLiteral> = ({ node, metadata }) =>
+  ts.factory.createObjectLiteralExpression(
+    [
+      ...(metadata ?? []),
+      ts.factory.createPropertyAssignment(
+        "type",
+        ts.factory.createStringLiteral("literal")
+      ),
+      ts.factory.createPropertyAssignment(
+        "typeLiteral",
+        ts.factory.createStringLiteral("bigint")
+      ),
+      ts.factory.createPropertyAssignment(
+        "value",
+        ts.factory.createBigIntLiteral(node.text)
+      ),
+    ],
+    true
+  );

--- a/packages/core/src/lib/visit/visitNever.ts
+++ b/packages/core/src/lib/visit/visitNever.ts
@@ -1,0 +1,6 @@
+import ts from "typescript";
+
+import { Visiter } from "../helpers/types";
+
+export const visitNever: Visiter<ts.KeywordTypeNode> = () =>
+  ts.factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);

--- a/packages/core/src/lib/visit/visitNever.ts
+++ b/packages/core/src/lib/visit/visitNever.ts
@@ -3,4 +3,9 @@ import ts from "typescript";
 import { Visiter } from "../helpers/types";
 
 export const visitNever: Visiter<ts.KeywordTypeNode> = () =>
-  ts.factory.createKeywordTypeNode(ts.SyntaxKind.NeverKeyword);
+  ts.factory.createObjectLiteralExpression([
+    ts.factory.createPropertyAssignment(
+      "type",
+      ts.factory.createStringLiteral("never")
+    ),
+  ]);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -152,6 +152,10 @@ export type NullTsRuntimeObject = {
   readonly type: "null";
 } & GlobalTsRuntimeObjectKeys;
 
+export type NeverTsRuntimeObject = {
+  readonly type: "never";
+} & GlobalTsRuntimeObjectKeys;
+
 export type TsRuntimeObject =
   | FunctionTsRuntimeObject
   | ObjectTsRuntimeObject
@@ -174,7 +178,8 @@ export type TsRuntimeObject =
   | UnionTsRuntimeObject
   | PropertySignatureTsRuntimeObject
   | UndefinedTsRuntimeObject
-  | NullTsRuntimeObject;
+  | NullTsRuntimeObject
+  | NeverTsRuntimeObject;
 
 export type GenericTsRuntimeObject = TsRuntimeObject & {
   generics: TsRuntimeObjectGeneric[];


### PR DESCRIPTION
This PR contains the following:
- The visitor can now handle `never` and literals of type `bigint`
- The utils has a tsr object type for `never`
fixes: #100 